### PR TITLE
Add buzzer sound when RFID card is read

### DIFF
--- a/IOT/main/bin.cpp
+++ b/IOT/main/bin.cpp
@@ -119,16 +119,35 @@ MFRC522 rfid(PIN_RFID_SDA, PIN_RFID_RST);
 
 void readRFID(void *) {
   if (rfid.PICC_IsNewCardPresent()) {  // new tag is available
-    if (rfid.PICC_ReadCardSerial()) {  // NUID has been readed
+    if (rfid.PICC_ReadCardSerial()) {  // UID has been read
       DEBUG_PRINT_RFID(rfid.uid);
 
       if (strncmp(reinterpret_cast<const char *>(rfid.uid.uidByte), reinterpret_cast<const char *>(RFID_UID), RFID_UID_SIZE) == 0) {
         DEBUG_PRINT_RFID_SUCCESS();
         addSendData(trash1CollectRequested(), 1);
-        // TODO do sound when success
+        // high pitch sound on success
+        for (int i = 0; i < 20; i++) {
+          digitalWrite(PIN_BUZZER_SOURCE, HIGH);
+          delayMicroseconds(1200);
+          digitalWrite(PIN_BUZZER_SOURCE, LOW);
+          delayMicroseconds(1200);
+        }
+        delay(70);
+        for (int i = 0; i < 50; i++) {
+          digitalWrite(PIN_BUZZER_SOURCE, HIGH);
+          delayMicroseconds(800);
+          digitalWrite(PIN_BUZZER_SOURCE, LOW);
+          delayMicroseconds(800);
+        }
       } else {
         DEBUG_PRINT_RFID_FAILURE();
-        // TODO do sound when failure
+        // low pitch sound on failure
+        for (int i = 0; i < 30; i++) {
+          digitalWrite(PIN_BUZZER_SOURCE, HIGH);
+          delayMicroseconds(2200);
+          digitalWrite(PIN_BUZZER_SOURCE, LOW);
+          delayMicroseconds(2200);
+        }
       }
       rfid.PICC_HaltA();       // halt PICC
       rfid.PCD_StopCrypto1();  // stop encryption on PCD
@@ -145,4 +164,6 @@ void setupBins(void *) {
   Serial.print("RFID module version: ");
   rfid.PCD_DumpVersionToSerial();
 #endif
+
+  pinMode(PIN_BUZZER_SOURCE, OUTPUT);
 }

--- a/IOT/main/config.h.sample
+++ b/IOT/main/config.h.sample
@@ -22,6 +22,8 @@
 #define PIN_RFID_SDA 53
 #define PIN_RFID_RST 49
 
+#define PIN_BUZZER_SOURCE 46
+
 #define RFID_UID_SIZE 4
 // This UID is hardcoded in the white card
 #define DEFAULT_RFID_UID { 0xDA, 0x43, 0x96, 0x19 }


### PR DESCRIPTION
When invalid card is read : low pitch sound
When valid card is read : 2 ton, high pitch sound

> [!Note]
> The program uses sleep in loops to modify the pitch and blocks the cpu for ~200 ms.